### PR TITLE
Fixed crash on unable to setup graphics

### DIFF
--- a/include/gf3d_vgraphics.h
+++ b/include/gf3d_vgraphics.h
@@ -5,9 +5,9 @@
 
 #include "gf3d_vector.h"
 
-#define GF3D_VGRAPHICS_DISCRETE 1   //Choosing whether to use discrete [1] or integrated graphics [0]
+#define GF3D_VGRAPHICS_DISCRETE 2   //Choosing whether to use integrated [1], discrete [2], virtual [3], cpu [4]
 
-void gf3d_vgraphics_init(
+int gf3d_vgraphics_init(
     char *windowName,
     int renderWidth,
     int renderHeight,

--- a/include/gf3d_vgraphics.h
+++ b/include/gf3d_vgraphics.h
@@ -5,8 +5,6 @@
 
 #include "gf3d_vector.h"
 
-#define GF3D_VGRAPHICS_DISCRETE 2   //Choosing whether to use integrated [1], discrete [2], virtual [3], cpu [4]
-
 int gf3d_vgraphics_init(
     char *windowName,
     int renderWidth,

--- a/src/game.c
+++ b/src/game.c
@@ -15,14 +15,17 @@ int main(int argc,char *argv[])
     
     init_logger("gf3d.log");
     slog("gf3d begin");
-    gf3d_vgraphics_init(
+    if( gf3d_vgraphics_init(
         "gf3d",                 //program name
         1200,                   //screen width
         700,                    //screen height
         vector4d(0.51,0.75,1,1),//background color
         0,                      //fullscreen
         1                       //validation
-    );
+    ) != 0){
+        slog("Fail to initialize graphics, exiting...");
+        return -1;
+    }
     
     // main game loop
     while(!done)

--- a/src/gf3d_vgraphics.c
+++ b/src/gf3d_vgraphics.c
@@ -430,24 +430,28 @@ Bool gf3d_vgraphics_device_validate(VkPhysicalDevice device)
     slog("apiVersion: %i",deviceProperties.apiVersion);
     slog("driverVersion: %i",deviceProperties.driverVersion);
     slog("supports Geometry Shader: %i",deviceFeatures.geometryShader);
-    return (deviceProperties.deviceType == GF3D_VGRAPHICS_DISCRETE)&&(deviceFeatures.geometryShader);
+    return (deviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU || deviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU)&&(deviceFeatures.geometryShader);
 }
 
 VkPhysicalDevice gf3d_vgraphics_select_device()
 {
     int i;
+    VkPhysicalDeviceProperties deviceProperties;
     VkPhysicalDevice chosen = VK_NULL_HANDLE;
     for (i = 0; i < gf3d_vgraphics.device_count; i++)
     {
         if (gf3d_vgraphics_device_validate(gf3d_vgraphics.devices[i]))
         {
             chosen = gf3d_vgraphics.devices[i];
+            vkGetPhysicalDeviceFeatures(chosen, &deviceProperties);
+            if(deviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU){
+                return chosen;
+            }
         }
     }
 
     return chosen;
 }
-
 
 /**
  * VULKAN DEBUGGING CALLBACK SETUP

--- a/src/gf3d_vgraphics.c
+++ b/src/gf3d_vgraphics.c
@@ -430,7 +430,7 @@ Bool gf3d_vgraphics_device_validate(VkPhysicalDevice device)
     slog("apiVersion: %i",deviceProperties.apiVersion);
     slog("driverVersion: %i",deviceProperties.driverVersion);
     slog("supports Geometry Shader: %i",deviceFeatures.geometryShader);
-    return (deviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU || deviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU)&&(deviceFeatures.geometryShader);
+    return (deviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU || deviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)&&(deviceFeatures.geometryShader);
 }
 
 VkPhysicalDevice gf3d_vgraphics_select_device()


### PR DESCRIPTION
Device type in gf3d_graphics.h is based on [this specification](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceType.html)
Also `vkDestroyInstance(gf3d_vgraphics.vk_instance, NULL);`on line 305 raises error on exit. So I commented it out, until figure out what the problem.