### PR TITLE
Allocated correct size for command list

### DIFF
--- a/src/gf3d_commands.c
+++ b/src/gf3d_commands.c
@@ -50,7 +50,7 @@ void gf3d_command_system_init(Uint32 max_commands,VkDevice defaultDevice)
     }
     gf3d_commands.device = defaultDevice;
     gf3d_commands.max_commands = max_commands;
-    gf3d_commands.command_list = gf3d_allocate_array(sizeof(CommandManager),max_commands);
+    gf3d_commands.command_list = gf3d_allocate_array(sizeof(Command),max_commands);
     
     atexit(gf3d_command_system_close);
 }


### PR DESCRIPTION
Code crashes on exit because the manager tried to free up memory that was never allocated to it. Changed the size of the gf3d_allocate_array so that the correct amount of memory was allocated.