### PR TITLE
Correctly generate vqueues for different queue tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ dkms.conf
 makefile.dep
 gf3d
 *.log
+
+# CMake and CLion related ignores
+build/
+.idea/
+cmake-build-debug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.5)
+project(gf3d)
+
+# Requirements
+include(FindPkgConfig)
+
+pkg_search_module(SDL2 REQUIRED sdl2)
+pkg_search_module(SDL2IMAGE REQUIRED SDL2_image>=2.0.0)
+
+aux_source_directory(src/ SOURCE_FILES)
+
+include_directories(
+	include
+	${CMAKE_SOURCE_DIR}/gfc/include
+	${CMAKE_SOURCE_DIR}/gfc/simple_json/include
+	${CMAKE_SOURCE_DIR}/gfc/simple_logger/include
+	${SDL2_INCLUDE_DIRS} ${SDL2IMAGE_INCLUDE_DIRS})
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+
+target_link_libraries(${PROJECT_NAME} SDL2_image png jpeg z vulkan m
+
+	${CMAKE_SOURCE_DIR}/gfc/libs/libgfc.a
+	${CMAKE_SOURCE_DIR}/gfc/simple_json/libs/libsj.a
+	${CMAKE_SOURCE_DIR}/gfc/simple_logger/libs/libsl.a
+
+	${SDL2_LIBRARIES} ${SDL2IMAGE_LIBRARIES})

--- a/include/gf3d_vgraphics.h
+++ b/include/gf3d_vgraphics.h
@@ -8,7 +8,7 @@
 #include "gf3d_pipeline.h"
 #include "gf3d_commands.h"
 
-#define GF3D_VGRAPHICS_DISCRETE 1   //Choosing whether to use discrete [1] or integrated graphics [0]
+#define GF3D_VGRAPHICS_DISCRETE VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU   //Choosing whether to use discrete [1] or integrated graphics [0]
 
 /**
  * @brief init Vulkan / SDL, setup device and initialize infrastructure for 3d graphics

--- a/src/gf3d_vqueues.c
+++ b/src/gf3d_vqueues.c
@@ -6,235 +6,311 @@
 
 #include "gf3d_vqueues.h"
 
+/*
+ * -- Theory --
+ *
+ * Within Vulkan, and computer science at large, there is a concept called a "Queue". You might have heard the term before if you've ever talked to a
+ * cranky British person complaining about the line at a shopping center. A "Queue", as a concept, is a temporary storage space for a thing that is
+ * waiting to be processed. There are many different types of Queues. A non-exhaustive list of types of Queues that you *should* know the existence
+ * of: First-In-First-Out, Last-In-First-Out, and Priority.
+ *
+ * You use a Queue to separate the production of work from the completion of work. This prevents a situation called "Blocking" where a component (A) has a
+ * computation or piece of information it wants to pass to another component (B) but that other component (B) is busy doing other operations. In this case
+ * the first component (A) has to wait until the second component (B) is done with whatever it is working on before it can hand off it's work item. It is a
+ * really ugly case of hot-potato. If, however, a Queue is in between your two components (A & B) the Queue can immediately take the hot-potato from component
+ * A and when B is finished it can just take the work already stored in the Queue. It is important to note that this is only useful if A and B have about the
+ * same throughput over a long amount of time or if you are ok with dropping work (some expiration).
+ *
+ * In a similar way to how the line at your local DMV might look different from the line at your local grocery store different queues are designed with
+ * different use cases in mind. The engine the Queue is sitting in front, and the usage patterns of things that are put into the Queue, dictates how
+ * fast, what priority, and how complex the Queue must be.
+ *
+ * The GPU your graphics driver stack is talking, and the software that is talking to those drivers, are unimaginably more "complicated" then the DMV or your
+ * local ShopRight. Because of this the Vulkan spec allows driver writers and card manufacturers to build multiple queues fo different tasks between your
+ * software, the driver, and the hardware. They expose this concept with the aptly named VkQueue. Each Queue has "Physical Properties" that describe exactly
+ * what the hardware behind this queue can actually do. Example: A VkQueue might only be able to read and write to memory but might have absolutely no
+ * connection to the display memory of your GPU (Surface). This VkQueue would be able to transfer between CPU and GPU memory but NOT be able to ask the GPU to
+ * render a frame.
+ *
+ * In an ideal world, where all computers are infinitely fast, this is unnecessarily complex. This is purely a performance mitigation and we can see why this
+ * is so important if we relate our graphics software to real life Queues that exist in our day to day life.
+ *
+ * If we stick to the ShopRite example: If you do your shopping in the middle of the night so you can minimize human interaction, as well adjusted people like
+ * myself do, and you go to checkout there will likely be 1 lane and you will be the only one trying to check out. In this case there is effectively no Queue
+ * because the production of work (you attempting to check out) exactly matches the capacity of the worker (the cashier).
+ *
+ * If instead of 1 lane there were 4 open lanes: you now likely stood in front of the lanes, choose a lane a random, and went to check out with the cashier
+ * at the lane you choose. You might not have chosen the fastest lane but you "Queued" up and went to a single worker. This is an example of distributing a
+ * job across multiple workers. The Queue allows you to "fan-out" the number of workers behind it.
+ *
+ * And if instead of shopping during the middle of the night: you likely arrived at checkout with a non-zero amount of people (lets say 10) who have finished
+ * shopping at the same time as you. You all form a Queue and get dispatched to different workers. The workers don't (ideally) work faster or slower based on
+ * how backed up the Queue is. This is because work is coming in as batches (your batch was ~11 people) and as long as the workers process all of you before
+ * the next batch shows up all is well.
+ *
+ * (*warning* *warning* *warning*: major simplification)
+ *
+ * Now your GPU: A GPU can represent anywhere from 1 worker to 1000s of workers depending on design. Your graphics software also creates extremely peaky
+ * demands. If you're rendering your software at 60 frames per second your game can, at max, take ~15ms/frame to update it's internal state and shovel a HUGE
+ * number of updates to the GPU after that is done (render this, this memory changed, load this new shader, load this new texture, run this compute shader,
+ * etc). After the GPU gets & finishes that work it just sits idle until more work comes it's way. This is very similar to our shopping situation.
+ *
+ * -- Implementation --
+ *
+ * The VkPhysicalDevice contains a set number of provisionable slots for VkQueues to be allocated to. These slots have different
+ * VkQueueFamilyProperties which describe what each slot in the VkPhysicalDevice is capable of doing. This portion of the code has
+ * two main objectives:
+ *  GOAL 1. Create VkDeviceQueueCreateInfo packets that specifies how our VkDevice interact with these these queue families
+ *  GOAL 2. Retrieve instances of the VkQueue from the VkDevice when it is allocated
+ *  GOAL 3. Keep track of what each will a VkQueue we are going to use for what task (based on what features it supports)
+ */
+
+/**
+ * gf3d wrapper for Vulkan VkQueue that contains metadata useful to us.
+ */
+typedef struct
+{
+    /**
+     * Track if this VkQueue can be used for graphics (shader stuff), presentation (drawing to a surface), or transfer (memcpy) work.
+     */
+    VkBool32 graphics, present, transfer;
+    /**
+     * Pointer to a flat array of VkDeviceQueueCreationInfo structs.
+     */
+    VkDeviceQueueCreateInfo *creation_info;
+    /**
+     * Priority of this queue. We have a really simple application so ours will always be set to 1.0f.
+     */
+    float priority;
+    /**
+     * The ID of the Vulakn Queue Family. Vulkan docs will likely call this a "queueFamilyIndex"
+     */
+    Sint32 family;
+
+    /**
+     * Vulkan's application-level abstraction of what a "Queue" is.
+     */
+    VkQueue queue;
+} vQueue;
+
 
 typedef struct
 {
-    VkDeviceQueueCreateInfo     queue_info;
-    Uint32                      queue_family_count;
+    /**
+     * The number of available queue families on this card. We currently make use of every single one of
+     * them so this is also the number of VkQueue objects we will allocate. This is mainly done because
+     * we are lazy and don't care about performance.
+     */
+    Uint32                      num_available_queue_families;
+
+    /**
+     * Information about what each queue family can do.
+     *
+     * This information is polled from the VkPhysicalDevice using vkGetPhysicalDeviceQueueFamilyProperties.
+     */
     VkQueueFamilyProperties    *queue_properties;
-    VkQueue                     device_queue;
-    Sint32                      graphics_queue_family;
-    Sint32                      present_queue_family;
-    Sint32                      transfer_queue_family;
-    float                       graphics_queue_priority;
-    float                       present_queue_priority;
-    float                       transfer_queue_priority;
-    Uint32                      work_queue_count;
-    VkQueue                     graphics_queue;
-    VkQueue                     present_queue;
-    VkQueue                     transfer_queue;
-    VkDeviceQueueCreateInfo    *presentation_queue_info;
-    VkDeviceQueueCreateInfo    *queue_create_info;
-    VkDeviceQueueCreateInfo    *transfer_queue_info;
-}vQueues;
+    /**
+     * Information used when creating a VkDeice.
+     */
+    VkDeviceQueueCreateInfo    *creation_infos;
+    vQueue                     *queues;
+
+    // Pointers to the different vQueues we use for different work.
+    vQueue                     *graphics_queue;
+    vQueue                     *present_queue;
+    vQueue                     *transfer_queue;
+} vQueues;
 
 static vQueues gf3d_vqueues = {0};
 
 void gf3d_vqueues_close();
-VkDeviceQueueCreateInfo gf3d_vqueues_get_graphics_queue_info();
-VkDeviceQueueCreateInfo gf3d_vqueues_get_present_queue_info();
-VkDeviceQueueCreateInfo gf3d_vqueues_get_transfer_queue_info();
+
+/**
+ * Configure a vQueue wrapper with information polled from Vulkan.
+ * @param device - Physical device that has this queue attached
+ * @param surface - Surface we want to present to
+ * @param properties - What this queue is wired up to
+ * @param creation_info - Where to store information for VkDevice configuration process
+ * @param queue - The Queue itself
+ * @return true if everything went well. false if there was an issue talking to the GPU/Driver
+ */
+Bool gf3d_vqueues_init_configure_vqueue(VkPhysicalDevice device, VkSurfaceKHR surface, VkQueueFamilyProperties *properties, VkDeviceQueueCreateInfo *creation_info, vQueue *queue)
+{
+    if (!properties) {
+        slog("attempted to initialize vqueue from NULL VkQueueFamilyProperties");
+        return false;
+    }
+
+    if (!queue) {
+        slog("attempted to initialize vqueue into NULL");
+        return false;
+    }
+
+    // Make if this queue supports present, graphics, and transfer
+    if (vkGetPhysicalDeviceSurfaceSupportKHR(device, queue->family, surface, &queue->present) != VK_SUCCESS) {
+        slog("failed to query if queue family %d could present to a surface.", queue->family);
+        return false;
+    }
+    queue->graphics = properties->queueFlags & VK_QUEUE_GRAPHICS_BIT;
+    queue->transfer = properties->queueFlags & VK_QUEUE_TRANSFER_BIT;
+
+    // GOAL 1: Make a VkDeviceQueueCreationInfo packet for vulkan
+    queue->creation_info = creation_info;
+    memset(creation_info, 0, sizeof(VkDeviceQueueCreateInfo));
+    {
+        creation_info->sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+        creation_info->queueFamilyIndex = queue->family;
+        creation_info->queueCount = 1;
+        creation_info->pQueuePriorities = &queue->priority;
+    }
+
+    slog("queue family %d supports:");
+    slog("\t present: %d", (queue->present != 0));
+    slog("\ttransfer: %d", (queue->transfer != 0));
+    slog("\t    draw: %d", (queue->graphics != 0));
+    return true;
+}
+
+/**
+ * Count the total number of features this queue has.
+ * @param queue
+ * @return
+ */
+int gf3d_vqueues_feature_count(vQueue *queue)
+{
+    return (queue->present != 0) + (queue->transfer != 0) + (queue->graphics != 0);
+}
+
+vQueue *gf3d_vqueues_find_simplest_queue_for(Bool graphics, Bool transfer, Bool present)
+{
+    vQueue *chosen = NULL;
+
+    for (Uint32 i = 0; i < gf3d_vqueues.num_available_queue_families; i++)
+    {
+        vQueue *queue = &gf3d_vqueues.queues[i];
+
+        // Queue doesn't have correct configuration.
+        if ((graphics && !queue->graphics) || (transfer && !queue->transfer) || (present && !queue->present)) {
+            continue;
+        }
+
+        // Queue has more features than we actually need.
+        if (chosen && gf3d_vqueues_feature_count(chosen) < gf3d_vqueues_feature_count(queue)) {
+            continue;
+        }
+
+        chosen = queue;
+    }
+
+    return chosen;
+}
+/**
+ * Choose a vQueue for each queue task (graphics, transfer, present) based upon what it internally supports.
+ */
+void gf3d_vqueues_init_vqueue_assign_to_tasks()
+{
+    // GOAL 3: Assign a vQueue to each task we need to complete.
+    gf3d_vqueues.graphics_queue = gf3d_vqueues_find_simplest_queue_for(true, false, false);
+    gf3d_vqueues.transfer_queue = gf3d_vqueues_find_simplest_queue_for(false, true, false);
+    gf3d_vqueues.present_queue = gf3d_vqueues_find_simplest_queue_for(false, false, true);
+
+    slog("using queue family %i for graphics commands", gf3d_vqueues.graphics_queue->family);
+    slog("using queue family %i for rendering pipeline", gf3d_vqueues.present_queue->family);
+    slog("using queue family %i for transfer pipeline", gf3d_vqueues.transfer_queue->family);
+}
 
 void gf3d_vqueues_init(VkPhysicalDevice device,VkSurfaceKHR surface)
 {
-    Uint32 i;
-    VkBool32 supported;
-
-    gf3d_vqueues.graphics_queue_family = -1;
-    gf3d_vqueues.present_queue_family = -1;
-    gf3d_vqueues.transfer_queue_family = -1;
-    
-    vkGetPhysicalDeviceQueueFamilyProperties(
-        device,
-        &gf3d_vqueues.queue_family_count,
-        NULL);
-    
-    if (!gf3d_vqueues.queue_family_count)
+    // Find number of physical queues available on this device. This varies from card to card.
+    vkGetPhysicalDeviceQueueFamilyProperties(device, &gf3d_vqueues.num_available_queue_families, NULL);
+    slog("device reported queue family count: %i", gf3d_vqueues.num_available_queue_families);
+    if (!gf3d_vqueues.num_available_queue_families)
     {
         slog("failed to get any queue properties");
         gf3d_vqueues_close();
         return;
     }
-    
-    gf3d_vqueues.queue_properties = (VkQueueFamilyProperties*)gfc_allocate_array(sizeof(VkQueueFamilyProperties),gf3d_vqueues.queue_family_count);
-    
-    vkGetPhysicalDeviceQueueFamilyProperties(
-        device,
-        &gf3d_vqueues.queue_family_count,
-        gf3d_vqueues.queue_properties);
-    
-    slog("discoverd %i queue family properties",gf3d_vqueues.queue_family_count);
-    for (i = 0; i < gf3d_vqueues.queue_family_count; i++)
+
+    // Load all metadata about these queues from the card
+    gf3d_vqueues.queue_properties = (VkQueueFamilyProperties *) gfc_allocate_array(sizeof(VkQueueFamilyProperties), gf3d_vqueues.num_available_queue_families);
+    vkGetPhysicalDeviceQueueFamilyProperties(device, &gf3d_vqueues.num_available_queue_families, gf3d_vqueues.queue_properties);
+
+    // Allocate a vQueue for each of these queue families
+    gf3d_vqueues.creation_infos = (VkDeviceQueueCreateInfo *) gfc_allocate_array(sizeof(VkDeviceQueueCreateInfo), gf3d_vqueues.num_available_queue_families);
+    gf3d_vqueues.queues = (vQueue *) gfc_allocate_array(sizeof(vQueue), gf3d_vqueues.num_available_queue_families);
+    for (Uint32 i = 0; i < gf3d_vqueues.num_available_queue_families; i++)
     {
-        slog("Queue family %i:",i);
-        slog("queue flag bits %i",gf3d_vqueues.queue_properties[i].queueFlags);
-        slog("queue count %i",gf3d_vqueues.queue_properties[i].queueCount);
-        slog("queue timestamp valid bits %i",gf3d_vqueues.queue_properties[i].timestampValidBits);
+        VkDeviceQueueCreateInfo *creation_info = &gf3d_vqueues.creation_infos[i];
+        vQueue *queue = &gf3d_vqueues.queues[i];
+        VkQueueFamilyProperties *properties = &gf3d_vqueues.queue_properties[i];
+        slog("Queue family %i:", i);
+        slog("queue flag bits %i", properties->queueFlags);
+        slog("queue count %i", properties->queueCount);
+        slog("queue timestamp valid bits %i", properties->timestampValidBits);
         slog("queue min image transfer granularity %iw %ih %id",
-             gf3d_vqueues.queue_properties[i].minImageTransferGranularity.width,
-             gf3d_vqueues.queue_properties[i].minImageTransferGranularity.height,
-             gf3d_vqueues.queue_properties[i].minImageTransferGranularity.depth);
-        vkGetPhysicalDeviceSurfaceSupportKHR(
-            device,
-            i,
-            surface,
-            &supported);
-        if (gf3d_vqueues.queue_properties[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)
-        {
-            gf3d_vqueues.graphics_queue_family = i;
-            gf3d_vqueues.graphics_queue_priority = 1.0f;
-            slog("Queue handles graphics calls");
-        }
-        if (gf3d_vqueues.queue_properties[i].queueFlags & VK_QUEUE_TRANSFER_BIT)
-        {
-            gf3d_vqueues.transfer_queue_family = i;
-            gf3d_vqueues.transfer_queue_priority = 1.0f;
-            slog("Queue handles transfer calls");
-        }
-        if (supported)
-        {
-            gf3d_vqueues.present_queue_family = i;
-            gf3d_vqueues.present_queue_priority = 1.0f;
-            slog("Queue handles present calls");
-        }
+             properties->minImageTransferGranularity.width,
+             properties->minImageTransferGranularity.height,
+             properties->minImageTransferGranularity.depth);
+        queue->family = i;
+        queue->priority = 1.0f;
+        gf3d_vqueues_init_configure_vqueue(device, surface, properties, creation_info, &gf3d_vqueues.queues[i]);
+
     }
-    slog("using queue family %i for graphics commands",gf3d_vqueues.graphics_queue_family);
-    slog("using queue family %i for rendering pipeline",gf3d_vqueues.present_queue_family);
-    slog("using queue family %i for transfer pipeline",gf3d_vqueues.transfer_queue_family);
-    
-    if (gf3d_vqueues.graphics_queue_family != -1)
-    {
-        gf3d_vqueues.work_queue_count++;
-    }
-    if ((gf3d_vqueues.present_queue_family != -1) && (gf3d_vqueues.present_queue_family != gf3d_vqueues.graphics_queue_family))
-    {
-        gf3d_vqueues.work_queue_count++;
-    }
-    
-    if (!gf3d_vqueues.work_queue_count)
-    {
-        slog("No suitable queues for graphics calls or presentation");
-    }
-    else
-    {
-        gf3d_vqueues.queue_create_info = (VkDeviceQueueCreateInfo*)gfc_allocate_array(sizeof(VkDeviceQueueCreateInfo),gf3d_vqueues.work_queue_count);
-        slog("work queue count: %i",gf3d_vqueues.work_queue_count);
-        i = 0;
-        if (gf3d_vqueues.graphics_queue_family != -1)
-        {
-            gf3d_vqueues.queue_create_info[i++] = gf3d_vqueues_get_graphics_queue_info();
-        }
-        if ((gf3d_vqueues.present_queue_family != -1) && (gf3d_vqueues.present_queue_family != gf3d_vqueues.graphics_queue_family))
-        {
-            gf3d_vqueues.queue_create_info[i++] = gf3d_vqueues_get_present_queue_info();
-        }
-    }
-    
+
+    gf3d_vqueues_init_vqueue_assign_to_tasks();
+
     atexit(gf3d_vqueues_close);
 }
 
 const VkDeviceQueueCreateInfo *gf3d_vqueues_get_queue_create_info(Uint32 *count)
 {
-    if (count)*count = gf3d_vqueues.work_queue_count;
-    return gf3d_vqueues.queue_create_info;
-}
-
-VkDeviceQueueCreateInfo gf3d_vqueues_get_graphics_queue_info()
-{
-    VkDeviceQueueCreateInfo queueCreateInfo = {0};
-    queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-    queueCreateInfo.queueFamilyIndex = gf3d_vqueues.graphics_queue_family;
-    queueCreateInfo.queueCount = 1;
-    queueCreateInfo.pQueuePriorities = &gf3d_vqueues.graphics_queue_priority;
-    return queueCreateInfo;
-}
-
-VkDeviceQueueCreateInfo gf3d_vqueues_get_present_queue_info()
-{
-    VkDeviceQueueCreateInfo queueCreateInfo = {0};
-    queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-    queueCreateInfo.queueFamilyIndex = gf3d_vqueues.present_queue_family;
-    queueCreateInfo.queueCount = 1;
-    queueCreateInfo.pQueuePriorities = &gf3d_vqueues.present_queue_priority;
-    return queueCreateInfo;
-}
-
-VkDeviceQueueCreateInfo gf3d_vqueues_get_transfer_queue_info()
-{
-    VkDeviceQueueCreateInfo queueCreateInfo = {0};
-    queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-    queueCreateInfo.queueFamilyIndex = gf3d_vqueues.transfer_queue_family;
-    queueCreateInfo.queueCount = 1;
-    queueCreateInfo.pQueuePriorities = &gf3d_vqueues.transfer_queue_priority;
-    return queueCreateInfo;
-}
-
-void gf3d_vqueues_setup_device_queues(VkDevice device)
-{
-    if (gf3d_vqueues.graphics_queue_family != -1)
-    {
-        vkGetDeviceQueue(device, gf3d_vqueues.graphics_queue_family, 0, &gf3d_vqueues.graphics_queue);
-    }
-    if (gf3d_vqueues.present_queue_family != -1)
-    {
-        vkGetDeviceQueue(device, gf3d_vqueues.present_queue_family, 0, &gf3d_vqueues.present_queue);
-    }
-    if (gf3d_vqueues.transfer_queue_family != -1)
-    {
-        vkGetDeviceQueue(device, gf3d_vqueues.transfer_queue_family, 0, &gf3d_vqueues.transfer_queue);
-    }
+    if (count)*count = gf3d_vqueues.num_available_queue_families;
+    return gf3d_vqueues.creation_infos;
 }
 
 void gf3d_vqueues_close()
 {
     slog("cleaning up vulkan queues");
-    if (gf3d_vqueues.queue_create_info)
-    {
-        free(gf3d_vqueues.queue_create_info);
-    }
-    if (gf3d_vqueues.queue_properties)
-    {
-        free(gf3d_vqueues.queue_properties);
-    }
-    if (gf3d_vqueues.presentation_queue_info)
-    {
-        free(gf3d_vqueues.presentation_queue_info);
-    }
     memset(&gf3d_vqueues,0,sizeof(vQueues));
 }
 
-void gf3d_vqueues_create_presentation_queues()
+void gf3d_vqueues_setup_device_queues(VkDevice device)
 {
-    gf3d_vqueues.presentation_queue_info = (VkDeviceQueueCreateInfo*)gfc_allocate_array(sizeof(VkDeviceQueueCreateInfo),gf3d_vqueues.queue_family_count);
+    // GOAL 2: populate our internal pointers with reference to VkQueue. This allows dependencies on these pointers
+    // to be injected into other components of the application. See the below functions and their usages.
+    for (Uint32 i = 0; i < gf3d_vqueues.num_available_queue_families; i++) {
+        vQueue *queue = &gf3d_vqueues.queues[i];
+        vkGetDeviceQueue(device, queue->family, 0, &queue->queue);
+    }
 }
 
 Sint32 gf3d_vqueues_get_graphics_queue_family()
 {
-    return gf3d_vqueues.graphics_queue_family;
+    return gf3d_vqueues.graphics_queue->family;
 }
 
 Sint32 gf3d_vqueues_get_present_queue_family()
 {
-    return gf3d_vqueues.present_queue_family;
+    return gf3d_vqueues.present_queue->family;
 }
 
 Sint32 gf3d_vqueues_get_transfer_queue_family()
 {
-    return gf3d_vqueues.transfer_queue_family;
+    return gf3d_vqueues.transfer_queue->family;
 }
 
 VkQueue gf3d_vqueues_get_graphics_queue()
 {
-    return gf3d_vqueues.graphics_queue;
+    return gf3d_vqueues.graphics_queue->queue;
 }
 
 VkQueue gf3d_vqueues_get_present_queue()
 {
-    return gf3d_vqueues.present_queue;
+    return gf3d_vqueues.present_queue->queue;
 }
 
 VkQueue gf3d_vqueues_get_transfer_queue()
 {
-    return gf3d_vqueues.transfer_queue;
+    return gf3d_vqueues.transfer_queue->queue;
 }
 /*eol@eof*/


### PR DESCRIPTION
Hey DJ. This is the same queue-selection logic PR you saw this summer but this time the issues with stuttering and validation errors should have been addressed. I'm resubmitting this because I can't get the main engine to run on a GTX 1070. This PR addresses the issues I'm having and documents that code a little bit better. IT should also offer better queue selection for other laptops with more complicated queue configurations that we're seeing. 

I get the following error when attempting to run master @ DJ's HEAD:

```
game.c:36: gf3d begin
gf3d_extensions.c:68: Total available instance extensions: 17
gf3d_extensions.c:81: available instance extension: VK_KHR_device_group_creation
gf3d_extensions.c:81: available instance extension: VK_KHR_external_fence_capabilities
gf3d_extensions.c:81: available instance extension: VK_KHR_external_memory_capabilities
gf3d_extensions.c:81: available instance extension: VK_KHR_external_semaphore_capabilities
gf3d_extensions.c:81: available instance extension: VK_KHR_get_display_properties2
gf3d_extensions.c:81: available instance extension: VK_KHR_get_physical_device_properties2
gf3d_extensions.c:81: available instance extension: VK_KHR_get_surface_capabilities2
gf3d_extensions.c:81: available instance extension: VK_KHR_surface
gf3d_extensions.c:81: available instance extension: VK_KHR_wayland_surface
gf3d_extensions.c:81: available instance extension: VK_KHR_xcb_surface
gf3d_extensions.c:81: available instance extension: VK_KHR_xlib_surface
gf3d_extensions.c:81: available instance extension: VK_KHR_display
gf3d_extensions.c:81: available instance extension: VK_EXT_direct_mode_display
gf3d_extensions.c:81: available instance extension: VK_EXT_acquire_xlib_display
gf3d_extensions.c:81: available instance extension: VK_EXT_display_surface_counter
gf3d_extensions.c:81: available instance extension: VK_EXT_debug_report
gf3d_extensions.c:81: available instance extension: VK_EXT_debug_utils
gf3d_vgraphics.c:215: SDL Vulkan extensions support: VK_KHR_surface
gf3d_vgraphics.c:215: SDL Vulkan extensions support: VK_KHR_xlib_surface
gf3d_validation.c:26: discovered 10 validation layers
gf3d_validation.c:37: Validation layer available: VK_LAYER_VALVE_steam_overlay_64
gf3d_validation.c:37: Validation layer available: VK_LAYER_VALVE_steam_overlay_32
gf3d_validation.c:37: Validation layer available: VK_LAYER_VALVE_steam_fossilize_32
gf3d_validation.c:37: Validation layer available: VK_LAYER_VALVE_steam_fossilize_64
gf3d_validation.c:37: Validation layer available: VK_LAYER_LUNARG_object_tracker
gf3d_validation.c:37: Validation layer available: VK_LAYER_GOOGLE_threading
gf3d_validation.c:37: Validation layer available: VK_LAYER_LUNARG_core_validation
gf3d_validation.c:37: Validation layer available: VK_LAYER_LUNARG_standard_validation
gf3d_validation.c:37: Validation layer available: VK_LAYER_GOOGLE_unique_objects
gf3d_validation.c:37: Validation layer available: VK_LAYER_LUNARG_parameter_validation
gf3d_vgraphics.c:514: VULKAN DEBUG [1]:Added messenger
gf3d_vgraphics.c:514: VULKAN DEBUG [1]:Added messenger
gf3d_vgraphics.c:514: VULKAN DEBUG [1]:Added messenger
gf3d_vgraphics.c:514: VULKAN DEBUG [1]:Added messenger
gf3d_vgraphics.c:514: VULKAN DEBUG [1]:Added messenger
gf3d_vgraphics.c:276: vulkan discovered 1 device(s) with this instance
gf3d_vgraphics.c:479: Device Name: GeForce GTX 1070
gf3d_vgraphics.c:480: Dedicated GPU: 1
gf3d_vgraphics.c:481: apiVersion: 4198495
gf3d_vgraphics.c:482: driverVersion: 1754136576
gf3d_vgraphics.c:483: supports Geometry Shader: 1
gf3d_vqueues.c:66: discoverd 3 queue family properties
gf3d_vqueues.c:69: Queue family 0:
gf3d_vqueues.c:70: queue flag bits 15
gf3d_vqueues.c:71: queue count 16
gf3d_vqueues.c:72: queue timestamp valid bits 64
gf3d_vqueues.c:76: queue min image transfer granularity 1w 1h 1d
gf3d_vqueues.c:86: Queue handles graphics calls
gf3d_vqueues.c:92: Queue handles transfer calls
gf3d_vqueues.c:98: Queue handles present calls
gf3d_vqueues.c:69: Queue family 1:
gf3d_vqueues.c:70: queue flag bits 4
gf3d_vqueues.c:71: queue count 1
gf3d_vqueues.c:72: queue timestamp valid bits 64
gf3d_vqueues.c:76: queue min image transfer granularity 1w 1h 1d
gf3d_vqueues.c:92: Queue handles transfer calls
gf3d_vqueues.c:69: Queue family 2:
gf3d_vqueues.c:70: queue flag bits 2
gf3d_vqueues.c:71: queue count 8
gf3d_vqueues.c:72: queue timestamp valid bits 64
gf3d_vqueues.c:76: queue min image transfer granularity 1w 1h 1d
gf3d_vqueues.c:101: using queue family 0 for graphics commands
gf3d_vqueues.c:102: using queue family 0 for rendering pipeline
gf3d_vqueues.c:103: using queue family 1 for transfer pipeline
gf3d_vqueues.c:121: work queue count: 1
gf3d_extensions.c:30: Total available device extensions: 66
gf3d_extensions.c:44: available device extension: VK_KHR_8bit_storage
gf3d_extensions.c:44: available device extension: VK_KHR_16bit_storage
gf3d_extensions.c:44: available device extension: VK_KHR_bind_memory2
gf3d_extensions.c:44: available device extension: VK_KHR_create_renderpass2
gf3d_extensions.c:44: available device extension: VK_KHR_dedicated_allocation
gf3d_extensions.c:44: available device extension: VK_KHR_depth_stencil_resolve
gf3d_extensions.c:44: available device extension: VK_KHR_descriptor_update_template
gf3d_extensions.c:44: available device extension: VK_KHR_device_group
gf3d_extensions.c:44: available device extension: VK_KHR_draw_indirect_count
gf3d_extensions.c:44: available device extension: VK_KHR_driver_properties
gf3d_extensions.c:44: available device extension: VK_KHR_external_fence
gf3d_extensions.c:44: available device extension: VK_KHR_external_fence_fd
gf3d_extensions.c:44: available device extension: VK_KHR_external_memory
gf3d_extensions.c:44: available device extension: VK_KHR_external_memory_fd
gf3d_extensions.c:44: available device extension: VK_KHR_external_semaphore
gf3d_extensions.c:44: available device extension: VK_KHR_external_semaphore_fd
gf3d_extensions.c:44: available device extension: VK_KHR_get_memory_requirements2
gf3d_extensions.c:44: available device extension: VK_KHR_image_format_list
gf3d_extensions.c:44: available device extension: VK_KHR_maintenance1
gf3d_extensions.c:44: available device extension: VK_KHR_maintenance2
gf3d_extensions.c:44: available device extension: VK_KHR_maintenance3
gf3d_extensions.c:44: available device extension: VK_KHR_multiview
gf3d_extensions.c:44: available device extension: VK_KHR_push_descriptor
gf3d_extensions.c:44: available device extension: VK_KHR_relaxed_block_layout
gf3d_extensions.c:44: available device extension: VK_KHR_sampler_mirror_clamp_to_edge
gf3d_extensions.c:44: available device extension: VK_KHR_sampler_ycbcr_conversion
gf3d_extensions.c:44: available device extension: VK_KHR_shader_atomic_int64
gf3d_extensions.c:44: available device extension: VK_KHR_shader_draw_parameters
gf3d_extensions.c:44: available device extension: VK_KHR_shader_float16_int8
gf3d_extensions.c:44: available device extension: VK_KHR_shader_float_controls
gf3d_extensions.c:44: available device extension: VK_KHR_storage_buffer_storage_class
gf3d_extensions.c:44: available device extension: VK_KHR_swapchain
gf3d_extensions.c:44: available device extension: VK_KHR_swapchain_mutable_format
gf3d_extensions.c:44: available device extension: VK_KHR_variable_pointers
gf3d_extensions.c:44: available device extension: VK_KHR_vulkan_memory_model
gf3d_extensions.c:44: available device extension: VK_EXT_blend_operation_advanced
gf3d_extensions.c:44: available device extension: VK_EXT_conditional_rendering
gf3d_extensions.c:44: available device extension: VK_EXT_conservative_rasterization
gf3d_extensions.c:44: available device extension: VK_EXT_depth_range_unrestricted
gf3d_extensions.c:44: available device extension: VK_EXT_descriptor_indexing
gf3d_extensions.c:44: available device extension: VK_EXT_discard_rectangles
gf3d_extensions.c:44: available device extension: VK_EXT_display_control
gf3d_extensions.c:44: available device extension: VK_EXT_global_priority
gf3d_extensions.c:44: available device extension: VK_EXT_inline_uniform_block
gf3d_extensions.c:44: available device extension: VK_EXT_post_depth_coverage
gf3d_extensions.c:44: available device extension: VK_EXT_sample_locations
gf3d_extensions.c:44: available device extension: VK_EXT_sampler_filter_minmax
gf3d_extensions.c:44: available device extension: VK_EXT_scalar_block_layout
gf3d_extensions.c:44: available device extension: VK_EXT_shader_subgroup_ballot
gf3d_extensions.c:44: available device extension: VK_EXT_shader_subgroup_vote
gf3d_extensions.c:44: available device extension: VK_EXT_shader_viewport_index_layer
gf3d_extensions.c:44: available device extension: VK_EXT_transform_feedback
gf3d_extensions.c:44: available device extension: VK_EXT_vertex_attribute_divisor
gf3d_extensions.c:44: available device extension: VK_NV_clip_space_w_scaling
gf3d_extensions.c:44: available device extension: VK_NV_dedicated_allocation
gf3d_extensions.c:44: available device extension: VK_NV_device_diagnostic_checkpoints
gf3d_extensions.c:44: available device extension: VK_NV_fill_rectangle
gf3d_extensions.c:44: available device extension: VK_NV_fragment_coverage_to_color
gf3d_extensions.c:44: available device extension: VK_NV_framebuffer_mixed_samples
gf3d_extensions.c:44: available device extension: VK_NV_geometry_shader_passthrough
gf3d_extensions.c:44: available device extension: VK_NV_sample_mask_override_coverage
gf3d_extensions.c:44: available device extension: VK_NV_shader_subgroup_partitioned
gf3d_extensions.c:44: available device extension: VK_NV_viewport_array2
gf3d_extensions.c:44: available device extension: VK_NV_viewport_swizzle
gf3d_extensions.c:44: available device extension: VK_NVX_device_generated_commands
gf3d_extensions.c:44: available device extension: VK_NVX_multiview_per_view_attributes
gf3d_vgraphics.c:514: VULKAN DEBUG [4096]:/home/gravypod/.steam/ubuntu12_32/libVkLayer_steam_fossilize.so: wrong ELF class: ELFCLASS32
gf3d_vgraphics.c:514: VULKAN DEBUG [4096]:/home/gravypod/.steam/ubuntu12_32/steamoverlayvulkanlayer.so: wrong ELF class: ELFCLASS32
gf3d_vgraphics.c:514: VULKAN DEBUG [4096]:vkGetDeviceQueue: queueFamilyIndex (= 1) is not one of the queue families given via VkDeviceQueueCreateInfo structures when the device was created. The Vulkan spec states: queueFamilyIndex must be one of the queue family indices specified when device was created, via the VkDeviceQueueCreateInfo structure (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkGetDeviceQueue-queueFamilyIndex-00384)
Process finished with exit code 139 (interrupted by signal 11: SIGSEGV)
```

Output from running `correctly-generate-vqueues-for-different-queue-tasks` on my system with validation layers enabled: 
```
game.c:36: gf3d begin
gf3d_extensions.c:68: Total available instance extensions: 17
gf3d_extensions.c:81: available instance extension: VK_KHR_device_group_creation
gf3d_extensions.c:81: available instance extension: VK_KHR_external_fence_capabilities
gf3d_extensions.c:81: available instance extension: VK_KHR_external_memory_capabilities
gf3d_extensions.c:81: available instance extension: VK_KHR_external_semaphore_capabilities
gf3d_extensions.c:81: available instance extension: VK_KHR_get_display_properties2
gf3d_extensions.c:81: available instance extension: VK_KHR_get_physical_device_properties2
gf3d_extensions.c:81: available instance extension: VK_KHR_get_surface_capabilities2
gf3d_extensions.c:81: available instance extension: VK_KHR_surface
gf3d_extensions.c:81: available instance extension: VK_KHR_wayland_surface
gf3d_extensions.c:81: available instance extension: VK_KHR_xcb_surface
gf3d_extensions.c:81: available instance extension: VK_KHR_xlib_surface
gf3d_extensions.c:81: available instance extension: VK_KHR_display
gf3d_extensions.c:81: available instance extension: VK_EXT_direct_mode_display
gf3d_extensions.c:81: available instance extension: VK_EXT_acquire_xlib_display
gf3d_extensions.c:81: available instance extension: VK_EXT_display_surface_counter
gf3d_extensions.c:81: available instance extension: VK_EXT_debug_report
gf3d_extensions.c:81: available instance extension: VK_EXT_debug_utils
gf3d_vgraphics.c:215: SDL Vulkan extensions support: VK_KHR_surface
gf3d_vgraphics.c:215: SDL Vulkan extensions support: VK_KHR_xlib_surface
gf3d_validation.c:26: discovered 10 validation layers
gf3d_validation.c:37: Validation layer available: VK_LAYER_VALVE_steam_overlay_64
gf3d_validation.c:37: Validation layer available: VK_LAYER_VALVE_steam_overlay_32
gf3d_validation.c:37: Validation layer available: VK_LAYER_VALVE_steam_fossilize_32
gf3d_validation.c:37: Validation layer available: VK_LAYER_VALVE_steam_fossilize_64
gf3d_validation.c:37: Validation layer available: VK_LAYER_LUNARG_object_tracker
gf3d_validation.c:37: Validation layer available: VK_LAYER_GOOGLE_threading
gf3d_validation.c:37: Validation layer available: VK_LAYER_LUNARG_core_validation
gf3d_validation.c:37: Validation layer available: VK_LAYER_LUNARG_standard_validation
gf3d_validation.c:37: Validation layer available: VK_LAYER_GOOGLE_unique_objects
gf3d_validation.c:37: Validation layer available: VK_LAYER_LUNARG_parameter_validation
gf3d_vgraphics.c:514: VULKAN DEBUG [1]:Added messenger
gf3d_vgraphics.c:514: VULKAN DEBUG [1]:Added messenger
gf3d_vgraphics.c:514: VULKAN DEBUG [1]:Added messenger
gf3d_vgraphics.c:514: VULKAN DEBUG [1]:Added messenger
gf3d_vgraphics.c:514: VULKAN DEBUG [1]:Added messenger
gf3d_vgraphics.c:276: vulkan discovered 1 device(s) with this instance
gf3d_vgraphics.c:479: Device Name: GeForce GTX 1070
gf3d_vgraphics.c:480: Dedicated GPU: 1
gf3d_vgraphics.c:481: apiVersion: 4198495
gf3d_vgraphics.c:482: driverVersion: 1754136576
gf3d_vgraphics.c:483: supports Geometry Shader: 1
gf3d_vqueues.c:226: device reported queue family count: 3
gf3d_vqueues.c:246: Queue family 0:
gf3d_vqueues.c:247: queue flag bits 15
gf3d_vqueues.c:248: queue count 16
gf3d_vqueues.c:249: queue timestamp valid bits 64
gf3d_vqueues.c:253: queue min image transfer granularity 1w 1h 1d
gf3d_vqueues.c:167: queue family 0 supports:
gf3d_vqueues.c:168: 	 present: 1
gf3d_vqueues.c:169: 	transfer: 1
gf3d_vqueues.c:170: 	    draw: 1
gf3d_vqueues.c:246: Queue family 1:
gf3d_vqueues.c:247: queue flag bits 4
gf3d_vqueues.c:248: queue count 1
gf3d_vqueues.c:249: queue timestamp valid bits 64
gf3d_vqueues.c:253: queue min image transfer granularity 1w 1h 1d
gf3d_vqueues.c:167: queue family 0 supports:
gf3d_vqueues.c:168: 	 present: 0
gf3d_vqueues.c:169: 	transfer: 1
gf3d_vqueues.c:170: 	    draw: 0
gf3d_vqueues.c:246: Queue family 2:
gf3d_vqueues.c:247: queue flag bits 2
gf3d_vqueues.c:248: queue count 8
gf3d_vqueues.c:249: queue timestamp valid bits 64
gf3d_vqueues.c:253: queue min image transfer granularity 1w 1h 1d
gf3d_vqueues.c:167: queue family 0 supports:
gf3d_vqueues.c:168: 	 present: 0
gf3d_vqueues.c:169: 	transfer: 0
gf3d_vqueues.c:170: 	    draw: 0
gf3d_vqueues.c:217: using queue family 0 for graphics commands
gf3d_vqueues.c:218: using queue family 0 for rendering pipeline
gf3d_vqueues.c:219: using queue family 1 for transfer pipeline
gf3d_extensions.c:30: Total available device extensions: 66
gf3d_extensions.c:44: available device extension: VK_KHR_8bit_storage
gf3d_extensions.c:44: available device extension: VK_KHR_16bit_storage
gf3d_extensions.c:44: available device extension: VK_KHR_bind_memory2
gf3d_extensions.c:44: available device extension: VK_KHR_create_renderpass2
gf3d_extensions.c:44: available device extension: VK_KHR_dedicated_allocation
gf3d_extensions.c:44: available device extension: VK_KHR_depth_stencil_resolve
gf3d_extensions.c:44: available device extension: VK_KHR_descriptor_update_template
gf3d_extensions.c:44: available device extension: VK_KHR_device_group
gf3d_extensions.c:44: available device extension: VK_KHR_draw_indirect_count
gf3d_extensions.c:44: available device extension: VK_KHR_driver_properties
gf3d_extensions.c:44: available device extension: VK_KHR_external_fence
gf3d_extensions.c:44: available device extension: VK_KHR_external_fence_fd
gf3d_extensions.c:44: available device extension: VK_KHR_external_memory
gf3d_extensions.c:44: available device extension: VK_KHR_external_memory_fd
gf3d_extensions.c:44: available device extension: VK_KHR_external_semaphore
gf3d_extensions.c:44: available device extension: VK_KHR_external_semaphore_fd
gf3d_extensions.c:44: available device extension: VK_KHR_get_memory_requirements2
gf3d_extensions.c:44: available device extension: VK_KHR_image_format_list
gf3d_extensions.c:44: available device extension: VK_KHR_maintenance1
gf3d_extensions.c:44: available device extension: VK_KHR_maintenance2
gf3d_extensions.c:44: available device extension: VK_KHR_maintenance3
gf3d_extensions.c:44: available device extension: VK_KHR_multiview
gf3d_extensions.c:44: available device extension: VK_KHR_push_descriptor
gf3d_extensions.c:44: available device extension: VK_KHR_relaxed_block_layout
gf3d_extensions.c:44: available device extension: VK_KHR_sampler_mirror_clamp_to_edge
gf3d_extensions.c:44: available device extension: VK_KHR_sampler_ycbcr_conversion
gf3d_extensions.c:44: available device extension: VK_KHR_shader_atomic_int64
gf3d_extensions.c:44: available device extension: VK_KHR_shader_draw_parameters
gf3d_extensions.c:44: available device extension: VK_KHR_shader_float16_int8
gf3d_extensions.c:44: available device extension: VK_KHR_shader_float_controls
gf3d_extensions.c:44: available device extension: VK_KHR_storage_buffer_storage_class
gf3d_extensions.c:44: available device extension: VK_KHR_swapchain
gf3d_extensions.c:44: available device extension: VK_KHR_swapchain_mutable_format
gf3d_extensions.c:44: available device extension: VK_KHR_variable_pointers
gf3d_extensions.c:44: available device extension: VK_KHR_vulkan_memory_model
gf3d_extensions.c:44: available device extension: VK_EXT_blend_operation_advanced
gf3d_extensions.c:44: available device extension: VK_EXT_conditional_rendering
gf3d_extensions.c:44: available device extension: VK_EXT_conservative_rasterization
gf3d_extensions.c:44: available device extension: VK_EXT_depth_range_unrestricted
gf3d_extensions.c:44: available device extension: VK_EXT_descriptor_indexing
gf3d_extensions.c:44: available device extension: VK_EXT_discard_rectangles
gf3d_extensions.c:44: available device extension: VK_EXT_display_control
gf3d_extensions.c:44: available device extension: VK_EXT_global_priority
gf3d_extensions.c:44: available device extension: VK_EXT_inline_uniform_block
gf3d_extensions.c:44: available device extension: VK_EXT_post_depth_coverage
gf3d_extensions.c:44: available device extension: VK_EXT_sample_locations
gf3d_extensions.c:44: available device extension: VK_EXT_sampler_filter_minmax
gf3d_extensions.c:44: available device extension: VK_EXT_scalar_block_layout
gf3d_extensions.c:44: available device extension: VK_EXT_shader_subgroup_ballot
gf3d_extensions.c:44: available device extension: VK_EXT_shader_subgroup_vote
gf3d_extensions.c:44: available device extension: VK_EXT_shader_viewport_index_layer
gf3d_extensions.c:44: available device extension: VK_EXT_transform_feedback
gf3d_extensions.c:44: available device extension: VK_EXT_vertex_attribute_divisor
gf3d_extensions.c:44: available device extension: VK_NV_clip_space_w_scaling
gf3d_extensions.c:44: available device extension: VK_NV_dedicated_allocation
gf3d_extensions.c:44: available device extension: VK_NV_device_diagnostic_checkpoints
gf3d_extensions.c:44: available device extension: VK_NV_fill_rectangle
gf3d_extensions.c:44: available device extension: VK_NV_fragment_coverage_to_color
gf3d_extensions.c:44: available device extension: VK_NV_framebuffer_mixed_samples
gf3d_extensions.c:44: available device extension: VK_NV_geometry_shader_passthrough
gf3d_extensions.c:44: available device extension: VK_NV_sample_mask_override_coverage
gf3d_extensions.c:44: available device extension: VK_NV_shader_subgroup_partitioned
gf3d_extensions.c:44: available device extension: VK_NV_viewport_array2
gf3d_extensions.c:44: available device extension: VK_NV_viewport_swizzle
gf3d_extensions.c:44: available device extension: VK_NVX_device_generated_commands
gf3d_extensions.c:44: available device extension: VK_NVX_multiview_per_view_attributes
gf3d_vgraphics.c:514: VULKAN DEBUG [4096]:/home/gravypod/.steam/ubuntu12_32/libVkLayer_steam_fossilize.so: wrong ELF class: ELFCLASS32
gf3d_vgraphics.c:514: VULKAN DEBUG [4096]:/home/gravypod/.steam/ubuntu12_32/steamoverlayvulkanlayer.so: wrong ELF class: ELFCLASS32
gf3d_swapchain.c:52: device supports 2 surface formats
gf3d_swapchain.c:59: surface format 0:
gf3d_swapchain.c:60: format: 44
gf3d_swapchain.c:61: colorspace: 0
gf3d_swapchain.c:59: surface format 1:
gf3d_swapchain.c:60: format: 50
gf3d_swapchain.c:61: colorspace: 0
gf3d_swapchain.c:67: device supports 3 presentation modes
gf3d_swapchain.c:74: presentation mode: 0 is 2
gf3d_swapchain.c:74: presentation mode: 1 is 3
gf3d_swapchain.c:74: presentation mode: 2 is 0
gf3d_swapchain.c:79: chosing surface format 0
gf3d_swapchain.c:82: chosing presentation mode 1
gf3d_swapchain.c:214: Requested resolution: (1200,700)
gf3d_swapchain.c:215: Minimum resolution: (1200,700)
gf3d_swapchain.c:216: Maximum resolution: (1200,700)
gf3d_swapchain.c:85: chosing swap chain extent of (1200,700)
gf3d_swapchain.c:144: minimum images needed for swap chain: 2
gf3d_swapchain.c:145: Maximum images needed for swap chain: 8
gf3d_swapchain.c:148: using 3 images for the swap chain
gf3d_swapchain.c:190: created a swap chain with length 3
gf3d_swapchain.c:201: created swap chain with 3 images
gf3d_swapchain.c:208: create image views
gf3d_mesh.c:60: mesh system initialized
gf3d_texture.c:23: initializing texture system
gf3d_texture.c:38: texture system initialized
gf3d_pipeline.c:40: pipeline manager created with chain length 3
gf3d_pipeline.c:42: pipeline system initialized
gf3d_pipeline.c:407: attempting to make 3 descriptor pools of size 1024
gf3d_pipeline.c:448: making descriptor
gf3d_pipeline.c:466: allocating descriptor sets
gf3d_pipeline.c:466: allocating descriptor sets
gf3d_pipeline.c:466: allocating descriptor sets
gf3d_model.c:58: model manager initiliazed
gf3d_commands.c:46: command pool system init
gf3d_commands.c:133: created command buffer pool
gf3d_swapchain.c:115: created framebuffer
gf3d_swapchain.c:115: created framebuffer
gf3d_swapchain.c:115: created framebuffer
game.c:47: gf3d main loop begin
gf3d_mesh.c:244: created a mesh with 63996 vertices and 21332 face
gf3d_texture.c:197: created texture sampler
gf3d_texture.c:293: created texture for image: images/dino.png
game.c:92: gf3d program end
gf3d_commands.c:41: command pool system closed
gf3d_model.c:42: model manager closed
gf3d_pipeline.c:48: cleaning up pipelines
gf3d_pipeline.c:353: cleaning up pipeline descriptor pool
gf3d_pipeline.c:353: cleaning up pipeline descriptor pool
gf3d_pipeline.c:353: cleaning up pipeline descriptor pool
gf3d_texture.c:43: cleaning up textures
gf3d_mesh.c:130: cleaning up mesh data
gf3d_mesh.c:147: mesh models/dino.obj face buffer freed
gf3d_mesh.c:152: mesh models/dino.obj face buffer memory freed
gf3d_mesh.c:157: mesh models/dino.obj vert buffer freed
gf3d_mesh.c:162: mesh models/dino.obj vert buffer memory freed
gf3d_mesh.c:138: mesh system closed
gf3d_swapchain.c:259: cleaning up swapchain
gf3d_swapchain.c:278: framebuffer destroyed
gf3d_swapchain.c:278: framebuffer destroyed
gf3d_swapchain.c:278: framebuffer destroyed
gf3d_swapchain.c:288: imageview destroyed
gf3d_swapchain.c:288: imageview destroyed
gf3d_swapchain.c:288: imageview destroyed
gf3d_extensions.c:51: cleaning up device extensions
gf3d_vqueues.c:273: cleaning up vulkan queues
gf3d_vgraphics.c:319: cleaning up vulkan graphics
gf3d_extensions.c:88: cleaning up instance extentions
Process finished with exit code 0

```
